### PR TITLE
add docker file and shell script to run notebook in a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM jupyter/scipy-notebook
+
+RUN pip install pystan

--- a/run-notebook-docker.sh
+++ b/run-notebook-docker.sh
@@ -1,0 +1,5 @@
+docker run \
+    -v `pwd`:/home/jovyan/Intro_BayesReg \
+    -w /home/jovyan/Intro_BayesReg \
+    -p 8888:8888 \
+    pystan-notebook jupyter notebook


### PR DESCRIPTION
Maybe it's helpful to containerize the Jupyter notebook for folks who can't or don't want to install pystan on their machine.

This worked on my machine running Mac OSX. The docker command to start the container will be different on Windows.
